### PR TITLE
com.utilities.encoder.wav 1.0.6

### DIFF
--- a/Utilities.Encoder.Wav/Packages/com.utilities.encoder.wav/Runtime/WavEncoder.cs
+++ b/Utilities.Encoder.Wav/Packages/com.utilities.encoder.wav/Runtime/WavEncoder.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
+using UnityEngine.Scripting;
 using Utilities.Async;
 using Utilities.Audio;
 using Microphone = Utilities.Audio.Microphone;
@@ -14,6 +15,9 @@ namespace Utilities.Encoding.Wav
 {
     public class WavEncoder : IEncoder
     {
+        [Preserve]
+        public WavEncoder() { }
+
         public async Task<Tuple<string, AudioClip>> StreamSaveToDiskAsync(AudioClip clip, string saveDirectory, CancellationToken cancellationToken, Action<Tuple<string, AudioClip>> callback = null, [CallerMemberName] string callingMethodName = null)
         {
             if (callingMethodName != nameof(RecordingManager.StartRecordingAsync))

--- a/Utilities.Encoder.Wav/Packages/com.utilities.encoder.wav/package.json
+++ b/Utilities.Encoder.Wav/Packages/com.utilities.encoder.wav/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Encoder.Wav",
   "description": "Simple library for WAV encoding support.",
   "keywords": [],
-  "version": "1.0.5",
+  "version": "1.0.6",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.encoder.wav#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.encoder.wav/releases",


### PR DESCRIPTION
- fixed an issue with default .ctr being stripped from builds