### PR TITLE
com.utilities.encoder.wav 1.2.1

### DIFF
--- a/Utilities.Encoder.Wav/Packages/com.utilities.encoder.wav/package.json
+++ b/Utilities.Encoder.Wav/Packages/com.utilities.encoder.wav/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Encoder.Wav",
   "description": "Simple library for WAV encoding support.",
   "keywords": [],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.encoder.wav#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.encoder.wav/releases",
@@ -17,7 +17,7 @@
     "url": "https://github.com/StephenHodgson"
   },
   "dependencies": {
-    "com.utilities.audio": "1.2.0"
+    "com.utilities.audio": "1.2.1"
   },
   "samples": [
     {

--- a/Utilities.Encoder.Wav/ProjectSettings/ProjectVersion.txt
+++ b/Utilities.Encoder.Wav/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.16f1
-m_EditorVersionWithRevision: 2022.3.16f1 (d2c21f0ef2f1)
+m_EditorVersion: 2021.3.38f1
+m_EditorVersionWithRevision: 2021.3.38f1 (7a2fa5d8d101)


### PR DESCRIPTION
- Fix backwards compatibility with 2021.3 LTS